### PR TITLE
feat(*): add loading class, pre-load script on hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,19 @@
 
 - Replaces DOM element with YouTube player on click
 - Auto-plays video when it's ready
-- Takes YouTube video ID from DOM
-- Loads YouTube API only when needed (on click) and only once (looks for window.YT.Player first)
+- Reads YouTube video ID from element attribute
+- Reads class name from element attribute and adds it while the player is loading
+- Loads YouTube API only when needed (on click and pre-load on hover) and only once (looks for window.YT or existing script tag first)
 
 HTML:
 ```html
-    <div class="youTubeVideo" video-id="m7MtIv9a0A4">Preview</div>
+    <div
+        class="youTubeVideo"
+        data-video-id="m7MtIv9a0A4"
+        data-loading-class="elementName--loading"
+    >
+        Preview
+    </div>
 ````
 
 JavaScript:

--- a/YouTubePlayer/YouTubePlayer.html
+++ b/YouTubePlayer/YouTubePlayer.html
@@ -7,11 +7,16 @@
                 height: 270px;
                 border: 1px solid salmon;
             }
+            .loading {
+                background-color: deeppink;
+            }
         </style>
     </head>
     <body>
-        <div id="player1" video-id="m7MtIv9a0A4">Preview here</div>
-        <div id="player2" video-id="m7MtIv9a0A4">Preview here</div>
+        <div id="player1" data-video-id="m7MtIv9a0A4" data-loading-class="loading">
+            Preview here
+        </div>
+        <div id="player2" data-video-id="m7MtIv9a0A4">Preview here</div>
     </body>
     <script type="module">
         import YouTubePlayer from './YouTubePlayer.js';

--- a/YouTubePlayer/YouTubePlayer.js
+++ b/YouTubePlayer/YouTubePlayer.js
@@ -10,8 +10,8 @@
  */
 export default class YouTubePlayer {
 
-    loadingClassAttribute = 'data-loading-class';
-    videoIdAttribute = 'data-video-id';
+    loadingClassAttribute = 'loadingClass';
+    videoIdAttribute = 'videoId';
     youTubeScriptURL = 'https://www.youtube.com/iframe_api';
 
     init(element) {
@@ -82,7 +82,7 @@ export default class YouTubePlayer {
      * @return {string}
      */
     getLoadingClass() {
-        const className = this.element.getAttribute(this.loadingClassAttribute) || '';
+        const className = this.element.dataset[this.loadingClassAttribute] || '';
         if (!className) {
             console.log(`YouTubePlayer: Attribute ${this.loadingClassAttribute} not set on element, cannot add loading class.`);
         }
@@ -91,7 +91,7 @@ export default class YouTubePlayer {
 
 
     displayAndPlayVideo() {
-        const videoId = this.element.getAttribute(this.videoIdAttribute);
+        const videoId = this.element.dataset[this.videoIdAttribute];
         if (!videoId) {
             console.error('YouTubePlayer: video-id attribute not set on DOM element, cannot play video');
         }

--- a/YouTubePlayer/YouTubePlayer.js
+++ b/YouTubePlayer/YouTubePlayer.js
@@ -8,14 +8,26 @@
  *    youTubePlayer.init(document.querySelector('.youTubeVideo'));
  * </script>
  */
-export default class {
-  
+export default class YouTubePlayer {
+
+    loadingClassAttribute = 'data-loading-class';
+    videoIdAttribute = 'data-video-id';
+    youTubeScriptURL = 'https://www.youtube.com/iframe_api';
+
     init(element) {
         if (!element || !(element instanceof HTMLElement)) {
             throw new Error(`YouTubePlayer: Argument provided for init function must be a HTMLElement, is ${element} instead.`);
         }
         this.element = element;
         this.setupClickListener();
+        this.setupHoverListener();
+    }
+
+    /**
+     * To minimize delay, pre-load YouTube script as soon as user hovers the video preview
+     */
+    setupHoverListener() {
+        this.element.addEventListener('mouseenter', this.loadYouTubeAPI.bind(this));
     }
   
     setupClickListener() {
@@ -30,8 +42,7 @@ export default class {
     async clickHandler() {
         // Click handler is only needed once; remove it as soon as it's been used
         this.removeClickHandler();
-        // Empty preview to give the user a quick feedback
-        this.element.innerHTML = '';
+        this.addLoadingClass();
         await this.loadYouTubeAPI();
         this.displayAndPlayVideo();
     }
@@ -39,27 +50,58 @@ export default class {
     async loadYouTubeAPI() {
         // YouTube script was already loaded, Player is ready
         if (window.YT && window.YT.Player && typeof window.YT.Player === 'function') return;
-        // Load YouTube iFrame API script
-        var tag = document.createElement('script');
-        tag.src = 'https://www.youtube.com/iframe_api';
-        var firstScriptTag = document.getElementsByTagName('script')[0];
-        firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+        // Check if there is already a YouTube script: If there is, just wait until it's done
+        const existingTag = document.querySelector(`script[src="${this.youTubeScriptURL}"]`)
+        // There is no script tag: Create and add it to the DOM
+        if (!existingTag) {
+            var tag = document.createElement('script');
+            tag.setAttribute('src', this.youTubeScriptURL);
+            // There must be a script somewhere as this code itself is a script
+            var firstScriptTag = document.getElementsByTagName('script')[0];
+            firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+        }
         return new Promise((resolve) => {
             window.onYouTubeIframeAPIReady = resolve;
         });
     }
 
-    displayAndPlayVideo() {
-        const videoId = this.element.getAttribute('video-id');
-        if (!videoId) {
-            console.warn('YouTubePlayer: video-id attribute not set on DOM element, cannot play video');
+    addLoadingClass() {
+        if (this.getLoadingClass()) {
+            requestAnimationFrame(() => this.element.classList.add(this.getLoadingClass()));
         }
+    }
+
+    removeLoadingClass() {
+        if (this.getLoadingClass()) {
+            requestAnimationFrame(() => this.element.classList.remove(this.getLoadingClass()));
+        }
+    }
+
+    /**
+     * Get name of class that should be added to element from element's attributes
+     * @return {string}
+     */
+    getLoadingClass() {
+        const className = this.element.getAttribute(this.loadingClassAttribute) || '';
+        if (!className) {
+            console.log(`YouTubePlayer: Attribute ${this.loadingClassAttribute} not set on element, cannot add loading class.`);
+        }
+        return className;
+    }
+
+
+    displayAndPlayVideo() {
+        const videoId = this.element.getAttribute(this.videoIdAttribute);
+        if (!videoId) {
+            console.error('YouTubePlayer: video-id attribute not set on DOM element, cannot play video');
+        }
+        this.removeLoadingClass();
         new window.YT.Player(this.element, {
             videoId: videoId,
             events: {
                 onReady: (ev) => ev.target.playVideo(),
             }
-        });        
+        });
     }
   
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@joinbox/ui-components",
+  "version": "0.1.0",
+  "description": "UI components for the web",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/joinbox/ui-components.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/joinbox/ui-components/issues"
+  },
+  "homepage": "https://github.com/joinbox/ui-components#readme"
+}


### PR DESCRIPTION
- Take data-loading-class attribute from element, add it as class while loading
- Pre-load YouTube script tag on mouseenter; make sure it's only loaded once
- Rename video-id attribute to data-video-id

BREAKING CHANGE: Rename DOM element attribute name

Before: video-id
After: data-video-id