### PR TITLE
fix(splitText): handle brs correctly in firefox

### DIFF
--- a/packages/splitText/splitText.js
+++ b/packages/splitText/splitText.js
@@ -68,6 +68,7 @@ var wrapLetters = (text, wrapLetter, startIndex = 0) => {
     return { index, result: wrappedLetters };
 };
 
+/* global Symbol */
 /**
  * Splits text in a HTML element into lines and wraps them with the function provided. It is
  * mandatory that all childNodes of the HTML element are HTMLElements (not bare text, comments or
@@ -78,6 +79,9 @@ var wrapLines = (element, wrapLine) => {
     // If there are no children (because the content is not wrapped in letters nor words), just
     // return one line: We cannot measure the y position of children that don't exist
     const { childNodes } = element;
+
+    // 1 = ElementNode
+    const isBreak = (htmlElement) => htmlElement.nodeType === 1 && htmlElement.tagName === 'BR';
 
     const childElements = [...childNodes].filter((node) => node.nodeType === 1);
     if (!childElements.length) {
@@ -98,6 +102,7 @@ var wrapLines = (element, wrapLine) => {
     // Elements with top of null will not be wrapped with wrapLine function.
     const adjustedTops = childrenWithTop.map((child, index) => {
         if (
+            // 3 = TextNode
             child.content.nodeType === 3
             && (childrenWithTop[index - 1]?.top === childrenWithTop[index + 1]?.top)
         ) {
@@ -109,23 +114,30 @@ var wrapLines = (element, wrapLine) => {
     // item is the top and all following elements are the children with that top; this allows
     // us to easily access the latest element (which is harder with Maps or objects)
     const lines = adjustedTops.reduce((previous, child) => {
-        if (child.top === previous.at(-1)?.at(0)) previous.at(-1).push(child.content);
+        // Use Symbol() to make sure the br gets its very own line; we could also use Math.random();
+        // <br> should never be wrapped, see below
+        if (isBreak(child.content)) previous.push([Symbol('brTop'), child.content]);
+        else if (child.top === previous.at(-1)?.at(0)) previous.at(-1).push(child.content);
         else previous.push([child.top, child.content]);
         return previous;
     }, []);
 
-    // Wrap all elements on the same line (except for spaces at their beginning or end) with
-    // wrapLine function
+    // Wrap the relevant elements on the same line with wrapLine function
     let lineIndex = 0;
-    const wrapped = lines.map(([top, ...content]) => {
-        // A child is a text element if there's only one of them and the top is null
-        if (content.length === 1 && top === null) return content[0].textContent;
-        // A child that is a <br> shall never be wrapped. Why? Within an element, it won't break
+    const wrapped = lines.map((allContent) => {
+        // Remove the first entry which is the top
+        const content = allContent.slice(1);
+        // Spaces are text nodes on their own line. As they should never be wrapped into an
+        // element; output their content as is.
+        if (content.length === 1 && content[0].nodeType === 3) return content[0].textContent;
+        // Handle single <br> elements just as we handle regular spaces above: don't wrap anyhting
+        // around them. Why? Within a wrapped element, the <br> won't break
         // the line correcly any more: <br/><br/> is not equal to
         // <span><br/></span><span><br/></span> (which will swallow breaks).
-        else if (content.length === 1 && content[0].tagName === 'BR') return content[0].outerHTML;
+        else if (content.length === 1 && isBreak(content[0])) return content[0].outerHTML;
         else {
             const contents = content.map((contentItem) => (
+                // 3 = TextNode
                 contentItem.nodeType === 3 ? contentItem.textContent : contentItem.outerHTML
             ));
             const result = wrapLine(contents.join(''), lineIndex);


### PR DESCRIPTION
Chrome puts <br> on a new line (different top than the other elements of that line); Firefox uses the same top. Make sure to never wrap <br> elements in a new line, also on Firefox.