### PR TITLE
fix(slide): don't test for identity of offset and scroll height when …

### DIFF
--- a/packages/slide/src/slide.mjs
+++ b/packages/slide/src/slide.mjs
@@ -37,13 +37,15 @@ export default ({
         if (target !== element) return;
         if (propertyName !== dimensionName.toLowerCase()) return;
         element.removeEventListener('transitionend', handleTransitionEnd);
-        if (element[`offset${dimensionName}`] === element[`scroll${dimensionName}`]) {
-            requestAnimationFrame(() => {
-                /* eslint-disable no-param-reassign */
-                element.style[dimensionName.toLowerCase()] = 'auto';
-                /* eslint-enable */
-            });
-        }
+        // In earlier versions, we tested here if the new offsetHeight was equal to the
+        // scrollHeight which, in some cases, did not happen; we were stuck with a fixed height,
+        // the element did not adjust its size on window resize or when elements were added.
+        // We now always reset the height to 'auto' at the end of the animation if no targetSize
+        // was provided.
+        requestAnimationFrame(() => {
+            // eslint-disable-next-line no-param-reassign
+            element.style[dimensionName.toLowerCase()] = 'auto';
+        });
         onEnd();
     };
     element.addEventListener('transitionend', handleTransitionEnd);


### PR DESCRIPTION
…setting dimension to 'auto'