### PR TITLE
fix(slide): do not reset height to auto after transitionend if a targ…

### DIFF
--- a/packages/slide/src/slide.mjs
+++ b/packages/slide/src/slide.mjs
@@ -42,10 +42,12 @@ export default ({
         // the element did not adjust its size on window resize or when elements were added.
         // We now always reset the height to 'auto' at the end of the animation if no targetSize
         // was provided.
-        requestAnimationFrame(() => {
-            // eslint-disable-next-line no-param-reassign
-            element.style[dimensionName.toLowerCase()] = 'auto';
-        });
+        if (targetSize === undefined) {
+            requestAnimationFrame(() => {
+                // eslint-disable-next-line no-param-reassign
+                element.style[dimensionName.toLowerCase()] = 'auto';
+            });
+        }
         onEnd();
     };
     element.addEventListener('transitionend', handleTransitionEnd);

--- a/packages/slide/src/slide.unit.mjs
+++ b/packages/slide/src/slide.unit.mjs
@@ -84,6 +84,11 @@ test('adjusts dimensions', async (t) => {
     t.is(widthDiv.style.width, '0px');
     t.is(heightDiv.style.height, '0px');
 
+    // Make sure height is not set to 'auto' when the function was called with a targetSize
+    heightDiv.dispatchEvent(heightTransitionEndEvent);
+    await new Promise((resolve) => setTimeout(resolve));
+    t.is(heightDiv.style.height, '0px');
+
     t.is(errors.length, 0);
 });
 


### PR DESCRIPTION
…etSize was provided

Bug introduced in the last commit, obviously wrong.