### PR TITLE
fix(slide): set height to 0 before measuring scrollHeight

### DIFF
--- a/packages/slide/src/slide.mjs
+++ b/packages/slide/src/slide.mjs
@@ -20,15 +20,28 @@ export default ({
 
     const dimensionName = dimension === 'x' ? 'Width' : 'Height';
     const initialSize = element[`offset${dimensionName}`];
-    const size = targetSize ?? element[`scroll${dimensionName}`];
+    let size;
+    if (targetSize !== undefined) size = targetSize;
+    else {
+        // If the new content is smaller than the current one, we cannot use offsetHeight or
+        // scrollHeight as both would return the dimensions of the (larger) old content – slide
+        // would never shrink. We therefore have to set its height to 0 for a supershort amount
+        // of time.
+        // eslint-disable-next-line no-param-reassign
+        element.style.height = 0;
+        size = element[`scroll${dimensionName}`];
+    }
 
+    // Don't use requestAnimationFrame here to minimize the amount of time we spend with a
+    // height of 0 (if targetSize was not provided and we set it to 0 to measure the scrollHeight)
+    // correctly.
+    // eslint-disable-next-line no-param-reassign
+    element.style[dimensionName.toLowerCase()] = `${initialSize}px`;
+    // We *must* use requestAnimationFrame here: Switching from 0 to size within no time would not
+    // execute the transition.
     requestAnimationFrame(() => {
-        /* eslint-disable no-param-reassign */
-        element.style[dimensionName.toLowerCase()] = `${initialSize}px`;
-        requestAnimationFrame(() => {
-            element.style[dimensionName.toLowerCase()] = `${size}px`;
-        });
-        /* eslint-enable */
+        // eslint-disable-next-line no-param-reassign
+        element.style[dimensionName.toLowerCase()] = `${size}px`;
     });
 
     // If element's height is set to its scrollHeight, reset numerical value to 'auto' at the


### PR DESCRIPTION
To make sure we correctly reduce the height through slide() when the new content is smaller than the current one