### PR TITLE
feat(114): add radio button support to faceted-search-filter-values

### DIFF
--- a/packages/FacetedSearch/src/FacetedSearchFilterValues.mjs
+++ b/packages/FacetedSearch/src/FacetedSearchFilterValues.mjs
@@ -1,7 +1,8 @@
 /**
  * Web component that wraps server-rendered filter value items.
- * Reads filter values from DOM, emits change events on checkbox toggle,
- * and updates expected result counts.
+ * Reads filter values from DOM, emits change events on input toggle,
+ * and updates expected result counts. Supports both checkbox (multi-select)
+ * and radio (single-select) inputs, detected automatically.
  */
 import { readAttribute } from '@helga-agency/ui-tools';
 import FilterValueItem from './FilterValueItem.mjs';
@@ -23,6 +24,13 @@ export default class FacetedSearchFilterValues extends HTMLElement {
 
     /** @type {boolean} */
     #isCollected = false;
+
+    /** @type {boolean} Derived from the first item's input type during collection */
+    #selectOneOnly = false;
+
+    /** @type {string|null} Tracks the active value for single-select filters;
+     *  needed because browsers don't fire change on the deselected radio. */
+    #activeValue = null;
 
     constructor() {
         super();
@@ -73,7 +81,7 @@ export default class FacetedSearchFilterValues extends HTMLElement {
         }));
     }
 
-    /** Lazily collects items and binds checkbox listeners. */
+    /** Lazily collects items and binds input listeners. */
     #ensureCollected() {
         if (this.#isCollected) return;
         this.#isCollected = true;
@@ -85,14 +93,42 @@ export default class FacetedSearchFilterValues extends HTMLElement {
         };
 
         const onChange = ({ value, selected }) => {
-            this.dispatchEvent(new CustomEvent('facetedSearchFilterChange', {
-                bubbles: true,
-                detail: { name: this.#filterName, value, selected },
-            }));
+            this.#handleChange(value, selected);
         };
 
         this.#items = [...this.querySelectorAll(this.#itemSelector)]
             .map((el) => new FilterValueItem(el, config, onChange));
+
+        this.#selectOneOnly = this.#items.length > 0 && this.#items[0].isRadio;
+    }
+
+    /**
+     * Handles an input change. When selectOneOnly is true, emits a deselect
+     * for the previously checked item before emitting the new selection.
+     * @param {string} value
+     * @param {boolean} selected
+     */
+    #handleChange(value, selected) {
+        if (this.#selectOneOnly && selected && this.#activeValue !== null && this.#activeValue !== value) {
+            this.#dispatch(this.#activeValue, false);
+        }
+
+        if (this.#selectOneOnly) {
+            this.#activeValue = selected ? value : null;
+        }
+
+        this.#dispatch(value, selected);
+    }
+
+    /**
+     * @param {string} value
+     * @param {boolean} selected
+     */
+    #dispatch(value, selected) {
+        this.dispatchEvent(new CustomEvent('facetedSearchFilterChange', {
+            bubbles: true,
+            detail: { name: this.#filterName, value, selected },
+        }));
     }
 
     /**
@@ -120,12 +156,18 @@ export default class FacetedSearchFilterValues extends HTMLElement {
     }
 
     /**
-     * Sets checkbox state programmatically (used by orchestrator for URL restore).
+     * Sets input state programmatically (used by orchestrator for URL restore).
+     * When selectOneOnly is true, deselects the previously checked item.
      * @param {string} value - The filter value to select
      * @param {boolean} selected
      */
     setChecked(value, selected) {
         this.#ensureCollected();
+
+        if (this.#selectOneOnly) {
+            this.#activeValue = selected ? value : null;
+        }
+
         const item = this.#items.find((entry) => entry.value === value);
         if (item) item.setChecked(selected);
     }

--- a/packages/FacetedSearch/src/FacetedSearchFilterValues.unit.mjs
+++ b/packages/FacetedSearch/src/FacetedSearchFilterValues.unit.mjs
@@ -169,3 +169,108 @@ test('setChecked sets checkbox state programmatically', async (t) => {
     t.true(checkbox.checked);
     t.is(errors.length, 0);
 });
+
+// select-one-only support
+
+const selectOneFilterHTML = `
+    <faceted-search-filter-values
+        data-filter-name="size"
+        data-item-selector=".filter-item"
+        data-item-value-selector="[data-value]"
+        data-item-id-selector="[data-id]"
+        data-item-amount-selector=".count"
+    >
+        <div class="filter-item" data-id="size-s" data-value="small">
+            <input type="radio" name="size" />
+            <span>Small</span>
+            <span class="count">0</span>
+        </div>
+        <div class="filter-item" data-id="size-m" data-value="medium">
+            <input type="radio" name="size" />
+            <span>Medium</span>
+            <span class="count">0</span>
+        </div>
+        <div class="filter-item" data-id="size-l" data-value="large">
+            <input type="radio" name="size" />
+            <span>Large</span>
+            <span class="count">0</span>
+        </div>
+    </faceted-search-filter-values>
+`;
+
+test('selectOneOnly: first selection emits only select event', async (t) => {
+    const { document, window } = await setup(true);
+    const container = document.createElement('div');
+    container.innerHTML = selectOneFilterHTML;
+    document.body.appendChild(container);
+
+    const component = document.querySelector('faceted-search-filter-values');
+    component.getFilterData();
+
+    const events = [];
+    component.addEventListener('facetedSearchFilterChange', (ev) => {
+        events.push(ev.detail);
+    });
+
+    const checkbox = document.querySelector('[data-value="small"] input');
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new window.Event('change', { bubbles: true }));
+
+    t.is(events.length, 1);
+    t.deepEqual(events[0], { name: 'size', value: 'small', selected: true });
+});
+
+test('selectOneOnly: selecting another value emits deselect then select', async (t) => {
+    const { document, window } = await setup(true);
+    const container = document.createElement('div');
+    container.innerHTML = selectOneFilterHTML;
+    document.body.appendChild(container);
+
+    const component = document.querySelector('faceted-search-filter-values');
+    component.getFilterData();
+
+    const events = [];
+    component.addEventListener('facetedSearchFilterChange', (ev) => {
+        events.push({ ...ev.detail });
+    });
+
+    const first = document.querySelector('[data-value="small"] input');
+    first.checked = true;
+    first.dispatchEvent(new window.Event('change', { bubbles: true }));
+
+    const second = document.querySelector('[data-value="medium"] input');
+    second.checked = true;
+    second.dispatchEvent(new window.Event('change', { bubbles: true }));
+
+    t.is(events.length, 3);
+    t.deepEqual(events[0], { name: 'size', value: 'small', selected: true });
+    t.deepEqual(events[1], { name: 'size', value: 'small', selected: false });
+    t.deepEqual(events[2], { name: 'size', value: 'medium', selected: true });
+});
+
+test('selectOneOnly: setChecked tracks active value for subsequent changes', async (t) => {
+    const { document, window } = await setup(true);
+    const container = document.createElement('div');
+    container.innerHTML = selectOneFilterHTML;
+    document.body.appendChild(container);
+
+    const component = document.querySelector('faceted-search-filter-values');
+
+    // Programmatically select "small"
+    component.setChecked('small', true);
+    t.true(document.querySelector('[data-value="small"] input').checked);
+
+    // Now simulate user clicking "medium" — should emit deselect for "small"
+    const events = [];
+    component.addEventListener('facetedSearchFilterChange', (ev) => {
+        events.push({ ...ev.detail });
+    });
+
+    const medium = document.querySelector('[data-value="medium"] input');
+    medium.checked = true;
+    medium.dispatchEvent(new window.Event('change', { bubbles: true }));
+
+    t.is(events.length, 2);
+    t.deepEqual(events[0], { name: 'size', value: 'small', selected: false });
+    t.deepEqual(events[1], { name: 'size', value: 'medium', selected: true });
+});

--- a/packages/FacetedSearch/src/FilterValueItem.mjs
+++ b/packages/FacetedSearch/src/FilterValueItem.mjs
@@ -1,7 +1,7 @@
 /**
  * Represents a single filter value item. Caches DOM references on construction,
- * binds checkbox listener, and exposes methods for updating count, toggling
- * empty class, and setting checkbox state.
+ * binds input listener, and exposes methods for updating count, toggling
+ * empty class, and setting checked state.
  * Not a web component — instantiated by FacetedSearchFilterValues.
  */
 import { readItemAttribute } from './extractItemData.mjs';
@@ -18,7 +18,7 @@ export default class FilterValueItem {
     #value;
 
     /** @type {HTMLInputElement|null} */
-    #checkbox;
+    #input;
 
     /** @type {HTMLElement|null} */
     #countElement;
@@ -35,14 +35,14 @@ export default class FilterValueItem {
         this.#element = element;
         this.#id = readItemAttribute(element, idSelector);
         this.#value = readItemAttribute(element, valueSelector);
-        this.#checkbox = element.querySelector('input[type="checkbox"]');
+        this.#input = element.querySelector('input[type="checkbox"], input[type="radio"]');
         this.#countElement = amountSelector
             ? element.querySelector(amountSelector)
             : null;
 
-        if (this.#checkbox) {
-            this.#checkbox.addEventListener('change', () => {
-                onChange({ value: this.#value, selected: this.#checkbox.checked });
+        if (this.#input) {
+            this.#input.addEventListener('change', () => {
+                onChange({ value: this.#value, selected: this.#input.checked });
             });
         }
     }
@@ -50,6 +50,8 @@ export default class FilterValueItem {
     get id() { return this.#id; }
     get value() { return this.#value; }
     get element() { return this.#element; }
+    get checked() { return this.#input ? this.#input.checked : false; }
+    get isRadio() { return this.#input?.type === 'radio'; }
 
     /**
      * Updates the displayed count and toggles the empty-result class.
@@ -63,6 +65,6 @@ export default class FilterValueItem {
 
     /** @param {boolean} selected */
     setChecked(selected) {
-        if (this.#checkbox) this.#checkbox.checked = selected;
+        if (this.#input) this.#input.checked = selected;
     }
 }

--- a/packages/FacetedSearch/src/FilterValueItem.unit.mjs
+++ b/packages/FacetedSearch/src/FilterValueItem.unit.mjs
@@ -81,7 +81,34 @@ test('calls onChange callback on checkbox change', (t) => {
     t.is(events[0].selected, true);
 });
 
-test('handles missing checkbox gracefully', (t) => {
+test('checked getter reflects input state', (t) => {
+    const el = createElement(
+        '<div data-id="cat-1" data-value="shoes"><input type="checkbox" /></div>',
+    );
+    const item = new FilterValueItem(el, config, noop);
+    t.false(item.checked);
+    item.setChecked(true);
+    t.true(item.checked);
+});
+
+test('checked returns false when no input exists', (t) => {
+    const el = createElement('<div data-id="cat-1" data-value="shoes"></div>');
+    const item = new FilterValueItem(el, config, noop);
+    t.false(item.checked);
+});
+
+test('isRadio returns true for radio, false for checkbox', (t) => {
+    const radio = createElement(
+        '<div data-id="cat-1" data-value="shoes"><input type="radio" name="x" /></div>',
+    );
+    const cb = createElement(
+        '<div data-id="cat-1" data-value="shoes"><input type="checkbox" /></div>',
+    );
+    t.true(new FilterValueItem(radio, config, noop).isRadio);
+    t.false(new FilterValueItem(cb, config, noop).isRadio);
+});
+
+test('handles missing input gracefully', (t) => {
     const el = createElement('<div data-id="cat-1" data-value="shoes"></div>');
     const item = new FilterValueItem(el, config, noop);
     item.setChecked(true);
@@ -93,4 +120,36 @@ test('handles missing count element gracefully', (t) => {
     const item = new FilterValueItem(el, { ...config, amountSelector: null }, noop);
     item.updateCount(5, null);
     t.pass();
+});
+
+// Radio input support
+
+test('finds and binds radio input', (t) => {
+    const dom = new JSDOM(
+        '<div data-id="cat-1" data-value="shoes"><input type="radio" name="category" /></div>',
+    );
+    const el = dom.window.document.body.firstChild;
+
+    const events = [];
+    new FilterValueItem(el, config, (detail) => events.push(detail));
+
+    const radio = el.querySelector('input');
+    radio.checked = true;
+    radio.dispatchEvent(new dom.window.Event('change'));
+
+    t.is(events.length, 1);
+    t.is(events[0].value, 'shoes');
+    t.is(events[0].selected, true);
+});
+
+test('setChecked works for radio inputs', (t) => {
+    const el = createElement(
+        '<div data-id="cat-1" data-value="shoes"><input type="radio" name="category" /></div>',
+    );
+    const item = new FilterValueItem(el, config, noop);
+    item.setChecked(true);
+    t.true(el.querySelector('input').checked);
+
+    item.setChecked(false);
+    t.false(el.querySelector('input').checked);
 });


### PR DESCRIPTION
Closes #114

## Changes

**FilterValueItem**: Support both `input[type="checkbox"]` and `input[type="radio"]`. Expose `checked` and `isRadio` getters.

**FacetedSearchFilterValues**: Detect single-select mode from radio input type. When a radio is selected, emit deselect for the previous value before emitting select for the new one. `setChecked` handles radios the same way.

No changes to the orchestrator or model — they already handle the event stream generically.

## Test coverage

- FilterValueItem: radio binding, `checked` getter, `isRadio` getter, `setChecked` for radios
- FacetedSearchFilterValues: first selection, deselect-then-select, programmatic `setChecked` with radios