### PR TITLE
refactor(115): prefix all registration events with facetedSearch

### DIFF
--- a/packages/FacetedSearch/src/FacetedSearch.mjs
+++ b/packages/FacetedSearch/src/FacetedSearch.mjs
@@ -43,12 +43,12 @@ export default class FacetedSearch extends HTMLElement {
     }
 
     connectedCallback() {
-        this.#listenForRegistration('registerSearchInput', this.#registerSearchInput);
-        this.#listenForRegistration('registerFilterValues', this.#registerFilterValues);
+        this.#listenForRegistration('facetedSearchRegisterSearchInput', this.#registerSearchInput);
+        this.#listenForRegistration('facetedSearchRegisterFilterValues', this.#registerFilterValues);
         this.#listenForRegistration('facetedSearchRegisterResultReader', this.#registerReader);
         this.#listenForRegistration('facetedSearchRegisterResultUpdater', this.#registerUpdater);
-        this.#listenForRegistration('unregisterSearchInput', this.#unregisterSearchInput);
-        this.#listenForRegistration('unregisterFilterValues', this.#unregisterFilterValues);
+        this.#listenForRegistration('facetedSearchUnregisterSearchInput', this.#unregisterSearchInput);
+        this.#listenForRegistration('facetedSearchUnregisterFilterValues', this.#unregisterFilterValues);
         this.#listenForRegistration('facetedSearchUnregisterResultReader', this.#unregisterReader);
         this.#listenForRegistration('facetedSearchUnregisterResultUpdater', this.#unregisterUpdater);
 

--- a/packages/FacetedSearch/src/FacetedSearch.unit.mjs
+++ b/packages/FacetedSearch/src/FacetedSearch.unit.mjs
@@ -89,10 +89,10 @@ test('errors on duplicate filter name', async (t) => {
     registerReaderAndUpdater(orchestrator, window);
 
     const filter1 = createMockFilterValues('category', [{ id: 'c1', value: 'shoes' }]);
-    fireRegistration(orchestrator, 'registerFilterValues', filter1, window);
+    fireRegistration(orchestrator, 'facetedSearchRegisterFilterValues', filter1, window);
 
     const filter2 = createMockFilterValues('category', [{ id: 'c2', value: 'hats' }]);
-    fireRegistration(orchestrator, 'registerFilterValues', filter2, window);
+    fireRegistration(orchestrator, 'facetedSearchRegisterFilterValues', filter2, window);
 
     t.is(errors.length, 1);
     t.regex(errors[0].message, /Duplicate filter name "category"/);
@@ -142,7 +142,7 @@ test('delegates filter change to model and updates children', async (t) => {
         { id: 'c2', value: 'hats' },
     ]);
 
-    fireRegistration(orchestrator, 'registerFilterValues', filterCategory, window);
+    fireRegistration(orchestrator, 'facetedSearchRegisterFilterValues', filterCategory, window);
     fireRegistration(orchestrator, 'facetedSearchRegisterResultReader', createMockReader(testItems), window);
     fireRegistration(orchestrator, 'facetedSearchRegisterResultUpdater', updater, window);
 
@@ -169,7 +169,7 @@ test('initializes model with item data from reader', async (t) => {
         { id: 'c2', value: 'hats' },
     ]);
 
-    fireRegistration(orchestrator, 'registerFilterValues', filterCategory, window);
+    fireRegistration(orchestrator, 'facetedSearchRegisterFilterValues', filterCategory, window);
     const { updater } = registerReaderAndUpdater(orchestrator, window);
 
     t.deepEqual(updater.lastVisibleIds, ['1', '2', '3']);
@@ -190,7 +190,7 @@ test('rebuilds model when filter registers after initialization', async (t) => {
         { id: 'c1', value: 'shoes' },
         { id: 'c2', value: 'hats' },
     ]);
-    fireRegistration(orchestrator, 'registerFilterValues', filterCategory, window);
+    fireRegistration(orchestrator, 'facetedSearchRegisterFilterValues', filterCategory, window);
 
     orchestrator.dispatchEvent(new window.CustomEvent('facetedSearchFilterChange', {
         bubbles: true,
@@ -252,7 +252,7 @@ test('writes search term to URL hash when input has propagateToUrl', async (t) =
     const orchestrator = document.querySelector('faceted-search');
     const mockInput = createMockSearchInput({ propagateToUrl: true });
 
-    fireRegistration(orchestrator, 'registerSearchInput', mockInput, window);
+    fireRegistration(orchestrator, 'facetedSearchRegisterSearchInput', mockInput, window);
     registerReaderAndUpdater(orchestrator, window);
 
     orchestrator.dispatchEvent(new window.CustomEvent('facetedSearchTermChange', {
@@ -283,7 +283,7 @@ test('writes filter state to URL hash when filter has propagateToUrl', async (t)
         { id: 'c2', value: 'hats' },
     ], { propagateToUrl: true });
 
-    fireRegistration(orchestrator, 'registerFilterValues', filterCategory, window);
+    fireRegistration(orchestrator, 'facetedSearchRegisterFilterValues', filterCategory, window);
     registerReaderAndUpdater(orchestrator, window);
 
     orchestrator.dispatchEvent(new window.CustomEvent('facetedSearchFilterChange', {
@@ -322,7 +322,7 @@ test('does not write to URL hash when propagateToUrl is false', async (t) => {
     const orchestrator = document.querySelector('faceted-search');
     const mockInput = createMockSearchInput({ propagateToUrl: false });
 
-    fireRegistration(orchestrator, 'registerSearchInput', mockInput, window);
+    fireRegistration(orchestrator, 'facetedSearchRegisterSearchInput', mockInput, window);
     registerReaderAndUpdater(orchestrator, window);
 
     orchestrator.dispatchEvent(new window.CustomEvent('facetedSearchTermChange', {
@@ -347,12 +347,12 @@ test('unregistering a filter component removes it from updates', async (t) => {
         { id: 'c2', value: 'hats' },
     ]);
 
-    fireRegistration(orchestrator, 'registerFilterValues', filterCategory, window);
+    fireRegistration(orchestrator, 'facetedSearchRegisterFilterValues', filterCategory, window);
     registerReaderAndUpdater(orchestrator, window);
     t.truthy(filterCategory.lastCounts);
 
     filterCategory.lastCounts = null;
-    fireRegistration(orchestrator, 'unregisterFilterValues', filterCategory, window);
+    fireRegistration(orchestrator, 'facetedSearchUnregisterFilterValues', filterCategory, window);
 
     orchestrator.dispatchEvent(new window.CustomEvent('facetedSearchTermChange', {
         bubbles: true,
@@ -406,7 +406,7 @@ test('unregistering updater stops visibility updates but keeps model', async (t)
     const filterCategory = createMockFilterValues('category', [
         { id: 'c1', value: 'shoes' },
     ]);
-    fireRegistration(orchestrator, 'registerFilterValues', filterCategory, window);
+    fireRegistration(orchestrator, 'facetedSearchRegisterFilterValues', filterCategory, window);
 
     orchestrator.dispatchEvent(new window.CustomEvent('facetedSearchFilterChange', {
         bubbles: true,
@@ -434,8 +434,8 @@ test('warns when a second search input registers', async (t) => {
 
     const input1 = createMockSearchInput();
     const input2 = createMockSearchInput();
-    fireRegistration(orchestrator, 'registerSearchInput', input1, window);
-    fireRegistration(orchestrator, 'registerSearchInput', input2, window);
+    fireRegistration(orchestrator, 'facetedSearchRegisterSearchInput', input1, window);
+    fireRegistration(orchestrator, 'facetedSearchRegisterSearchInput', input2, window);
 
     console.warn = originalWarn;
 

--- a/packages/FacetedSearch/src/FacetedSearchFilterValues.mjs
+++ b/packages/FacetedSearch/src/FacetedSearchFilterValues.mjs
@@ -67,7 +67,7 @@ export default class FacetedSearchFilterValues extends HTMLElement {
         /* Delay registration so the parent orchestrator has time to set up
            its listeners, even if this component's JS loads first. */
         setTimeout(() => {
-            this.dispatchEvent(new CustomEvent('registerFilterValues', {
+            this.dispatchEvent(new CustomEvent('facetedSearchRegisterFilterValues', {
                 bubbles: true,
                 detail: { element: this },
             }));
@@ -75,7 +75,7 @@ export default class FacetedSearchFilterValues extends HTMLElement {
     }
 
     disconnectedCallback() {
-        this.dispatchEvent(new CustomEvent('unregisterFilterValues', {
+        this.dispatchEvent(new CustomEvent('facetedSearchUnregisterFilterValues', {
             bubbles: true,
             detail: { element: this },
         }));

--- a/packages/FacetedSearch/src/FacetedSearchFilterValues.unit.mjs
+++ b/packages/FacetedSearch/src/FacetedSearchFilterValues.unit.mjs
@@ -44,7 +44,7 @@ test('registers with orchestrator via event containing component reference', asy
     container.innerHTML = filterHTML;
 
     const events = [];
-    container.addEventListener('registerFilterValues', (ev) => {
+    container.addEventListener('facetedSearchRegisterFilterValues', (ev) => {
         events.push(ev.detail);
     });
 

--- a/packages/FacetedSearch/src/FacetedSearchInput.mjs
+++ b/packages/FacetedSearch/src/FacetedSearchInput.mjs
@@ -54,7 +54,7 @@ export default class FacetedSearchInput extends HTMLElement {
         /* Delay registration so the parent orchestrator has time to set up
            its listeners, even if this component's JS loads first. */
         setTimeout(() => {
-            this.dispatchEvent(new CustomEvent('registerSearchInput', {
+            this.dispatchEvent(new CustomEvent('facetedSearchRegisterSearchInput', {
                 bubbles: true,
                 detail: { element: this },
             }));
@@ -62,7 +62,7 @@ export default class FacetedSearchInput extends HTMLElement {
     }
 
     disconnectedCallback() {
-        this.dispatchEvent(new CustomEvent('unregisterSearchInput', {
+        this.dispatchEvent(new CustomEvent('facetedSearchUnregisterSearchInput', {
             bubbles: true,
             detail: { element: this },
         }));

--- a/packages/FacetedSearch/src/FacetedSearchInput.unit.mjs
+++ b/packages/FacetedSearch/src/FacetedSearchInput.unit.mjs
@@ -23,7 +23,7 @@ test('registers with orchestrator via event containing component reference', asy
     container.innerHTML = inputHTML();
 
     const events = [];
-    container.addEventListener('registerSearchInput', (ev) => {
+    container.addEventListener('facetedSearchRegisterSearchInput', (ev) => {
         events.push(ev.detail);
     });
 


### PR DESCRIPTION
Closes #115

Renames the four unprefixed registration events to use the `facetedSearch` prefix:

| Old | New |
|-----|-----|
| `registerSearchInput` | `facetedSearchRegisterSearchInput` |
| `unregisterSearchInput` | `facetedSearchUnregisterSearchInput` |
| `registerFilterValues` | `facetedSearchRegisterFilterValues` |
| `unregisterFilterValues` | `facetedSearchUnregisterFilterValues` |

Updated in orchestrator listeners, component dispatchers, and all unit tests.